### PR TITLE
Fix post install command to work on Windows.

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "yearofmoo-angularjs-seed-repo",
   "version": "0.0.1",
   "scripts": {
-    "postinstall": "node ./node_modules/.bin/bower install"
+    "postinstall": "node ./node_modules/bower/bin/bower install"
   },
   "devDependencies": {
     "matchdep": "~0.1.2",


### PR DESCRIPTION
Former post install command does not work on Windows systems.
