### PR TITLE
Protractor changed the way it manages selenium

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -15,7 +15,7 @@ module.exports = function(grunt) {
         }
       },
       protractor_install: {
-        command: 'node ./node_modules/protractor/bin/install_selenium_standalone'
+        command: 'node ./node_modules/protractor/bin/webdriver-manager update'
       },
       npm_install: {
         command: 'npm install'


### PR DESCRIPTION
Protractor changed the way it manages selenium. It now uses webdriver-manager - https://github.com/angular/protractor/commit/e97ea351a69b53f9ce7bc4cb1f4c691a12b8f028
